### PR TITLE
Fix password history schema

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -29,7 +29,7 @@ model tokenBlacklist {
 
 model passwordHistory {
   id  Int @id @default(autoincrement())
-  userEmail String  @unique
+  userEmail String
   oldPasswordHash  String
   createdAt DateTime  @default(now())
   user            User   @relation(fields: [userEmail], references: [email])


### PR DESCRIPTION
## Summary
- allow multiple password history entries by removing the unique constraint

## Testing
- `npx -y jest --runInBand` *(fails: SyntaxError Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6862db93671883288f64eef614e66cf2