### PR TITLE
Fix typos in integration tests

### DIFF
--- a/server/src/tests/integration/forgotPassword.test.ts
+++ b/server/src/tests/integration/forgotPassword.test.ts
@@ -18,7 +18,7 @@ afterEach(async () => {
 })
 
 describe('POST /api/auth/forgot-password', () => {
-    it("Should return sucess: User logged in.", async () => {
+    it("Should return success: User logged in.", async () => {
         const email = `user+${uuidv4()}@example.com`
         const password = "Dream@505"
         await request(app).post('/api/auth/register').send({email: email, password: password})

--- a/server/src/tests/integration/login.test.ts
+++ b/server/src/tests/integration/login.test.ts
@@ -54,7 +54,7 @@ describe('POST /api/auth/login', () => {
         expect(res.status).toBe(401)
         expect(res.body).toHaveProperty('error', "Password is incorrect.")
     })
-    it("Should return sucess: User logged in.", async () => {
+    it("Should return success: User logged in.", async () => {
         const email = `user+${uuidv4()}@example.com`
         const password = "Dream@505"
         await request(app).post('/api/auth/register').send({email: email, password: password})


### PR DESCRIPTION
## Summary
- correct spelling in login and forgot password integration tests

## Testing
- `npm test --silent` *(fails: cannot find module 'cookie-parser', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6862dd1cb4fc8328bffe98ec6c87ab1f